### PR TITLE
Env via devenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,12 @@ cobertura.xml
 /roles/*/*-config.toml
 /examples/*/Cargo.lock
 /scripts/sv2.h
+# Devenv
+.devenv*
+devenv.local.nix
+
+# direnv
+.direnv
+
+# pre-commit
+.pre-commit-config.yaml

--- a/bitcoin.conf
+++ b/bitcoin.conf
@@ -1,0 +1,3 @@
+server=1
+rpcuser=username
+rpcpassword=password

--- a/bitcoind.nix
+++ b/bitcoind.nix
@@ -1,0 +1,25 @@
+
+{ pkgs, lib, ...}:
+let
+  src = pkgs.fetchFromGitHub {
+    owner = "Sjors";
+    repo = "bitcoin";
+    rev = "sv2";
+    hash = "sha256-iPVtR06DdheYRfZ/Edm1hu3JLoXAu5obddTQ38cqljs=";
+  };
+in pkgs.bitcoind.overrideAttrs (oldAttrs: {
+  name = "bitcoind-sv2";
+  src = src;
+  # ugly, drops autoconfHook as first list item
+  nativeBuildInputs = lib.lists.drop 1 oldAttrs.nativeBuildInputs ++ [pkgs.cmake];
+  # doCheck = false;
+  postInstall = "";
+  cmakeFlags = [
+    (lib.cmakeBool "WITH_SV2" true)
+    (lib.cmakeBool "BUILD_BENCH" true)
+    (lib.cmakeBool "BUILD_TESTS" true)
+    (lib.cmakeBool "ENABLE_WALLET" false)
+    (lib.cmakeBool "BUILD_GUI" false)
+    (lib.cmakeBool "BUILD_GUI_TESTS" false)
+  ];
+  })

--- a/bitcoind.nix
+++ b/bitcoind.nix
@@ -1,25 +1,28 @@
-
-{ pkgs, lib, ...}:
-let
+{
+  pkgs,
+  lib,
+  ...
+}: let
   src = pkgs.fetchFromGitHub {
     owner = "Sjors";
     repo = "bitcoin";
     rev = "sv2";
     hash = "sha256-iPVtR06DdheYRfZ/Edm1hu3JLoXAu5obddTQ38cqljs=";
   };
-in pkgs.bitcoind.overrideAttrs (oldAttrs: {
-  name = "bitcoind-sv2";
-  src = src;
-  # ugly, drops autoconfHook as first list item
-  nativeBuildInputs = lib.lists.drop 1 oldAttrs.nativeBuildInputs ++ [pkgs.cmake];
-  # doCheck = false;
-  postInstall = "";
-  cmakeFlags = [
-    (lib.cmakeBool "WITH_SV2" true)
-    (lib.cmakeBool "BUILD_BENCH" true)
-    (lib.cmakeBool "BUILD_TESTS" true)
-    (lib.cmakeBool "ENABLE_WALLET" false)
-    (lib.cmakeBool "BUILD_GUI" false)
-    (lib.cmakeBool "BUILD_GUI_TESTS" false)
-  ];
+in
+  pkgs.bitcoind.overrideAttrs (oldAttrs: {
+    name = "bitcoind-sv2";
+    src = src;
+    # ugly, drops autoconfHook as first list item
+    nativeBuildInputs = lib.lists.drop 1 oldAttrs.nativeBuildInputs ++ [pkgs.cmake];
+    # doCheck = false;
+    postInstall = "";
+    cmakeFlags = [
+      (lib.cmakeBool "WITH_SV2" true)
+      (lib.cmakeBool "BUILD_BENCH" true)
+      (lib.cmakeBool "BUILD_TESTS" true)
+      (lib.cmakeBool "ENABLE_WALLET" false)
+      (lib.cmakeBool "BUILD_GUI" false)
+      (lib.cmakeBool "BUILD_GUI_TESTS" false)
+    ];
   })

--- a/cpuminer.nix
+++ b/cpuminer.nix
@@ -1,0 +1,25 @@
+{ pkgs, ...}:
+let
+  src = pkgs.fetchFromGitHub {
+    owner = "pooler";
+    repo = "cpuminer";
+    rev = "v2.5.1";
+    hash = "sha256-ERBcFKAWsNW2UbqAfEaRsgIMcBfp+ggFA6LFjD6IhDg=";
+  };
+in pkgs.stdenv.mkDerivation {
+  name = "cpuminer";
+  inherit src;
+  buildInputs = [ pkgs.autoconf pkgs.automake pkgs.curl ];
+  configurePhase = ''
+    ./autogen.sh
+    ./configure CFLAGS="-O3"
+  '';
+   buildPhase = ''
+      make
+   '';
+   installPhase = ''
+     mkdir -p $out/bin
+     ls minerd
+     cp minerd $out/bin
+   '';
+}

--- a/cpuminer.nix
+++ b/cpuminer.nix
@@ -12,14 +12,13 @@ in pkgs.stdenv.mkDerivation {
   buildInputs = [ pkgs.autoconf pkgs.automake pkgs.curl ];
   configurePhase = ''
     ./autogen.sh
-    ./configure CFLAGS="-O3"
+    ./configure CFLAGS="-O3" --disable-assembly
   '';
    buildPhase = ''
       make
    '';
    installPhase = ''
      mkdir -p $out/bin
-     ls minerd
      cp minerd $out/bin
    '';
 }

--- a/cpuminer.nix
+++ b/cpuminer.nix
@@ -6,18 +6,23 @@ let
     rev = "v2.5.1";
     hash = "sha256-ERBcFKAWsNW2UbqAfEaRsgIMcBfp+ggFA6LFjD6IhDg=";
   };
+  configurePhase = if pkgs.stdenv.isDarwin then ''
+    ./autogen.sh
+    ./configure CFLAGS="-O3" --disable-assembly
+  ''
+  else ''
+    ./autogen.sh
+    ./configure CFLAGS="-O3"
+  '';
 in pkgs.stdenv.mkDerivation {
   name = "cpuminer";
   src = src;
   buildInputs = [ pkgs.autoconf pkgs.automake pkgs.curl ];
-  configurePhase = ''
-    ./autogen.sh
-    ./configure CFLAGS="-O3" --disable-assembly
-  '';
-   buildPhase = ''
+  configurePhase = configurePhase;
+  buildPhase = ''
       make
    '';
-   installPhase = ''
+  installPhase = ''
      mkdir -p $out/bin
      cp minerd $out/bin
    '';

--- a/cpuminer.nix
+++ b/cpuminer.nix
@@ -1,29 +1,31 @@
-{ pkgs, ...}:
-let
+{pkgs, ...}: let
   src = pkgs.fetchFromGitHub {
     owner = "pooler";
     repo = "cpuminer";
     rev = "v2.5.1";
     hash = "sha256-ERBcFKAWsNW2UbqAfEaRsgIMcBfp+ggFA6LFjD6IhDg=";
   };
-  configurePhase = if pkgs.stdenv.isDarwin then ''
-    ./autogen.sh
-    ./configure CFLAGS="-O3" --disable-assembly
-  ''
-  else ''
-    ./autogen.sh
-    ./configure CFLAGS="-O3"
-  '';
-in pkgs.stdenv.mkDerivation {
-  name = "cpuminer";
-  src = src;
-  buildInputs = [ pkgs.autoconf pkgs.automake pkgs.curl ];
-  configurePhase = configurePhase;
-  buildPhase = ''
+  configurePhase =
+    if pkgs.stdenv.isDarwin
+    then ''
+      ./autogen.sh
+      ./configure CFLAGS="-O3" --disable-assembly
+    ''
+    else ''
+      ./autogen.sh
+      ./configure CFLAGS="-O3"
+    '';
+in
+  pkgs.stdenv.mkDerivation {
+    name = "cpuminer";
+    src = src;
+    buildInputs = [pkgs.autoconf pkgs.automake pkgs.curl];
+    configurePhase = configurePhase;
+    buildPhase = ''
       make
-   '';
-  installPhase = ''
-     mkdir -p $out/bin
-     cp minerd $out/bin
-   '';
-}
+    '';
+    installPhase = ''
+      mkdir -p $out/bin
+      cp minerd $out/bin
+    '';
+  }

--- a/cpuminer.nix
+++ b/cpuminer.nix
@@ -8,7 +8,7 @@ let
   };
 in pkgs.stdenv.mkDerivation {
   name = "cpuminer";
-  inherit src;
+  src = src;
   buildInputs = [ pkgs.autoconf pkgs.automake pkgs.curl ];
   configurePhase = ''
     ./autogen.sh

--- a/devenv.lock
+++ b/devenv.lock
@@ -1,0 +1,276 @@
+{
+  "nodes": {
+    "cdk": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "pre-commit-hooks": "pre-commit-hooks",
+        "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "lastModified": 1728247460,
+        "owner": "cashubtc",
+        "repo": "cdk",
+        "rev": "260f262c395056ae243ccc8cfa0e9de793c5fd20",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cashubtc",
+        "repo": "cdk",
+        "type": "github"
+      }
+    },
+    "devenv": {
+      "locked": {
+        "dir": "src/modules",
+        "lastModified": 1728452860,
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "e7a0bc559f5a66aaa42f5028db6162c4dd4587eb",
+        "type": "github"
+      },
+      "original": {
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1726560853,
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "cdk",
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "gitignore_2": {
+      "inputs": {
+        "nixpkgs": [
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1728538411,
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b69de56fac8c2b6f8fd27f2eca01dcda8e0a4221",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1728500571,
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d51c28603def282a24fa034bcb007e2bcb5b5dd0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable_2": {
+      "locked": {
+        "lastModified": 1728500571,
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d51c28603def282a24fa034bcb007e2bcb5b5dd0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1716977621,
+        "owner": "cachix",
+        "repo": "devenv-nixpkgs",
+        "rev": "4267e705586473d3e5c8d50299e71503f16a6fb6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "rolling",
+        "repo": "devenv-nixpkgs",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-stable": "nixpkgs-stable"
+      },
+      "locked": {
+        "lastModified": 1728092656,
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "1211305a5b237771e13fcca0c51e60ad47326a9a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks_2": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
+        "gitignore": "gitignore_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": "nixpkgs-stable_2"
+      },
+      "locked": {
+        "lastModified": 1728092656,
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "1211305a5b237771e13fcca0c51e60ad47326a9a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "cdk": "cdk",
+        "devenv": "devenv",
+        "nixpkgs": "nixpkgs_2",
+        "pre-commit-hooks": "pre-commit-hooks_2"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "cdk",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1728527353,
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "94749eee5a2b351b6893d5bddb0a18f7f01251ac",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/devenv.nix
+++ b/devenv.nix
@@ -3,6 +3,7 @@ let
   minerd = import ./cpuminer.nix {inherit pkgs;};
   # override bitcoin's src attribute to get version 28
   bitcoind = pkgs.bitcoind.overrideAttrs (oldAttrs: {
+  name = "bitcoind-sv2";
   src = pkgs.fetchFromGitHub {
     owner = "Sjors";
     repo = "bitcoin";

--- a/devenv.nix
+++ b/devenv.nix
@@ -24,6 +24,9 @@ let
   ];
   });
 in {
+
+  env.BITCOIND_DATADIR = config.devenv.root + "/.devenv/state/bitcoind";
+
   # https://devenv.sh/packages/
   packages = [ bitcoind minerd ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [ pkgs.darwin.apple_sdk.frameworks.Security ];
 
@@ -45,11 +48,11 @@ in {
   # services.postgres.enable = true;
   # https://devenv.sh/scripts/
   scripts = {
-     run-local-pool.exec = "cargo -C roles/pool -Z unstable-options run -- -c $(pwd)/roles/pool/config-examples/pool-config-local-tp-example.toml";
-     run-job-server.exec = "cargo -C roles/jd-server -Z unstable-options run -- -c $(pwd)/roles/jd-server/config-examples/jds-config-local-example.toml";
-     run-job-client.exec = "cargo -C roles/jd-client -Z unstable-options run -- -c $(pwd)/roles/jd-client/config-examples/jdc-config-local-example.toml";
-     run-translator-proxy.exec = "cargo -C roles/translator -Z unstable-options run -- -c $(pwd)/roles/translator/config-examples/tproxy-config-local-jdc-example.toml";
-     bitcoind-testnet.exec = "bitcoind -testnet4 -sv2 -sv2port=8442 -debug=sv2 -conf=$(pwd)/bitcoin.conf";
+     run-local-pool.exec = "cargo -C roles/pool -Z unstable-options run -- -c $DEVENV_ROOT/roles/pool/config-examples/pool-config-local-tp-example.toml";
+     run-job-server.exec = "cargo -C roles/jd-server -Z unstable-options run -- -c $DEVENV_ROOT/roles/jd-server/config-examples/jds-config-local-example.toml";
+     run-job-client.exec = "cargo -C roles/jd-client -Z unstable-options run -- -c $DEVENV_ROOT/roles/jd-client/config-examples/jdc-config-local-example.toml";
+     run-translator-proxy.exec = "cargo -C roles/translator -Z unstable-options run -- -c $DEVENV_ROOT/roles/translator/config-examples/tproxy-config-local-jdc-example.toml";
+     bitcoind-testnet.exec = "bitcoind -testnet4 -sv2 -sv2port=8442 -debug=sv2 -conf=$DEVENV_ROOT/bitcoin.conf -datadir=$BITCOIND_DATADIR";
      run-minerd.exec = "minerd -a sha256d -o stratum+tcp://localhost:34255 -q -D -P";
   };
 
@@ -57,4 +60,9 @@ in {
   # https://devenv.sh/tests/
   # https://devenv.sh/pre-commit-hooks/
   # See full reference at https://devenv.sh/reference/options/
+
+  tasks."bitcoind:make_datadir" = {
+    exec = ''mkdir -p $BITCOIND_DATADIR'';
+    before = [ "devenv:enterShell" ];
+  };
 }

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,25 +1,32 @@
-{ pkgs, lib, config, inputs, ... }:
-let
-  minerd = import ./cpuminer.nix {pkgs=pkgs;};
-  bitcoind = import ./bitcoind.nix {pkgs=pkgs; lib=lib;};
+{
+  pkgs,
+  lib,
+  config,
+  inputs,
+  ...
+}: let
+  minerd = import ./cpuminer.nix {pkgs = pkgs;};
+  bitcoind = import ./bitcoind.nix {
+    pkgs = pkgs;
+    lib = lib;
+  };
 in {
-
   env.BITCOIND_DATADIR = config.devenv.root + "/.devenv/state/bitcoind";
 
   # https://devenv.sh/packages/
-  packages = [ bitcoind minerd ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [ pkgs.darwin.apple_sdk.frameworks.Security ];
+  packages = [bitcoind minerd] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [pkgs.darwin.apple_sdk.frameworks.Security];
 
   # https://devenv.sh/languages/
   languages.rust.enable = true;
 
   # https://devenv.sh/processes/
   processes = {
-     run-local-pool.exec = "run-local-pool";
-     run-job-server.exec = "run-job-server";
-     run-job-client.exec = "run-job-client";
-     run-translator-proxy.exec = "run-translator-proxy";
-     bitcoind-testnet.exec = "bitcoind-testnet";
-     run-minerd.exec = "run-minerd";
+    run-local-pool.exec = "run-local-pool";
+    run-job-server.exec = "run-job-server";
+    run-job-client.exec = "run-job-client";
+    run-translator-proxy.exec = "run-translator-proxy";
+    bitcoind-testnet.exec = "bitcoind-testnet";
+    run-minerd.exec = "run-minerd";
   };
 
   # https://devenv.sh/basics/
@@ -27,12 +34,12 @@ in {
   # services.postgres.enable = true;
   # https://devenv.sh/scripts/
   scripts = {
-     run-local-pool.exec = "cargo -C roles/pool -Z unstable-options run -- -c $DEVENV_ROOT/roles/pool/config-examples/pool-config-local-tp-example.toml";
-     run-job-server.exec = "cargo -C roles/jd-server -Z unstable-options run -- -c $DEVENV_ROOT/roles/jd-server/config-examples/jds-config-local-example.toml";
-     run-job-client.exec = "cargo -C roles/jd-client -Z unstable-options run -- -c $DEVENV_ROOT/roles/jd-client/config-examples/jdc-config-local-example.toml";
-     run-translator-proxy.exec = "cargo -C roles/translator -Z unstable-options run -- -c $DEVENV_ROOT/roles/translator/config-examples/tproxy-config-local-jdc-example.toml";
-     bitcoind-testnet.exec = "bitcoind -testnet4 -sv2 -sv2port=8442 -debug=sv2 -conf=$DEVENV_ROOT/bitcoin.conf -datadir=$BITCOIND_DATADIR";
-     run-minerd.exec = "minerd -a sha256d -o stratum+tcp://localhost:34255 -q -D -P";
+    run-local-pool.exec = "cargo -C roles/pool -Z unstable-options run -- -c $DEVENV_ROOT/roles/pool/config-examples/pool-config-local-tp-example.toml";
+    run-job-server.exec = "cargo -C roles/jd-server -Z unstable-options run -- -c $DEVENV_ROOT/roles/jd-server/config-examples/jds-config-local-example.toml";
+    run-job-client.exec = "cargo -C roles/jd-client -Z unstable-options run -- -c $DEVENV_ROOT/roles/jd-client/config-examples/jdc-config-local-example.toml";
+    run-translator-proxy.exec = "cargo -C roles/translator -Z unstable-options run -- -c $DEVENV_ROOT/roles/translator/config-examples/tproxy-config-local-jdc-example.toml";
+    bitcoind-testnet.exec = "bitcoind -testnet4 -sv2 -sv2port=8442 -debug=sv2 -conf=$DEVENV_ROOT/bitcoin.conf -datadir=$BITCOIND_DATADIR";
+    run-minerd.exec = "minerd -a sha256d -o stratum+tcp://localhost:34255 -q -D -P";
   };
 
   # https://devenv.sh/tasks/
@@ -42,6 +49,10 @@ in {
 
   tasks."bitcoind:make_datadir" = {
     exec = ''mkdir -p $BITCOIND_DATADIR'';
-    before = [ "devenv:enterShell" ];
+    before = ["devenv:enterShell"];
+  };
+
+  pre-commit.hooks = {
+    alejandra.enable = true;
   };
 }

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,28 +1,7 @@
 { pkgs, lib, config, inputs, ... }:
 let
   minerd = import ./cpuminer.nix {inherit pkgs;};
-  # override bitcoin's src attribute to get version 28
-  bitcoind = pkgs.bitcoind.overrideAttrs (oldAttrs: {
-  name = "bitcoind-sv2";
-  src = pkgs.fetchFromGitHub {
-    owner = "Sjors";
-    repo = "bitcoin";
-    rev = "sv2";
-    hash = "sha256-iPVtR06DdheYRfZ/Edm1hu3JLoXAu5obddTQ38cqljs=";
-  };
-  # ugly, drops autoconfHook as first list item
-  nativeBuildInputs = lib.lists.drop 1 oldAttrs.nativeBuildInputs ++ [pkgs.cmake];
-  # doCheck = false;
-  postInstall = "";
-  cmakeFlags = [
-    (lib.cmakeBool "WITH_SV2" true)
-    (lib.cmakeBool "BUILD_BENCH" true)
-    (lib.cmakeBool "BUILD_TESTS" true)
-    (lib.cmakeBool "ENABLE_WALLET" false)
-    (lib.cmakeBool "BUILD_GUI" false)
-    (lib.cmakeBool "BUILD_GUI_TESTS" false)
-  ];
-  });
+  bitcoind = import ./bitcoind.nix {pkgs=pkgs; lib=lib;};
 in {
 
   env.BITCOIND_DATADIR = config.devenv.root + "/.devenv/state/bitcoind";

--- a/devenv.nix
+++ b/devenv.nix
@@ -14,7 +14,9 @@ in {
   env.BITCOIND_DATADIR = config.devenv.root + "/.devenv/state/bitcoind";
 
   # https://devenv.sh/packages/
-  packages = [bitcoind minerd] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [pkgs.darwin.apple_sdk.frameworks.Security];
+  packages =
+    [bitcoind minerd pkgs.just]
+    ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [pkgs.darwin.apple_sdk.frameworks.Security];
 
   # https://devenv.sh/languages/
   languages.rust.enable = true;

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,6 +1,6 @@
 { pkgs, lib, config, inputs, ... }:
 let
-  minerd = import ./cpuminer.nix {inherit pkgs;};
+  minerd = import ./cpuminer.nix {pkgs=pkgs;};
   bitcoind = import ./bitcoind.nix {pkgs=pkgs; lib=lib;};
 in {
 

--- a/devenv.nix
+++ b/devenv.nix
@@ -31,11 +31,11 @@ in {
 
   # https://devenv.sh/processes/
   processes = {
-     run-local-pool.exec = "cargo -C roles/pool -Z unstable-options run -- -c roles/pool/config-examples/pool-config-local-tp-example.toml";
-     run-job-server.exec = "cargo -C roles/jd-server -Z unstable-options run -- -c roles/jd-server/config-examples/jds-config-local-example.toml";
-     run-job-client.exec = "cargo -C roles/jd-client -Z unstable-options run -- -c roles/jd-client/config-examples/jds-config-local-example.toml";
-     run-translator-proxy.exec = "cargo -C roles/translator -Z unstable-options run -- -c roles/translator/config-examples/tproxy-config-local-jdc-example.toml";
-     bitcoind-testnet.exec = "bitcoind -testnet4 -sv2 -sv2port=8442 -debug=sv2";
+     run-local-pool.exec = "cargo -C roles/pool -Z unstable-options run -- -c $(pwd)/roles/pool/config-examples/pool-config-local-tp-example.toml";
+     run-job-server.exec = "cargo -C roles/jd-server -Z unstable-options run -- -c $(pwd)/roles/jd-server/config-examples/jds-config-local-example.toml";
+     run-job-client.exec = "cargo -C roles/jd-client -Z unstable-options run -- -c $(pwd)/roles/jd-client/config-examples/jdc-config-local-example.toml";
+     run-translator-proxy.exec = "cargo -C roles/translator -Z unstable-options run -- -c $(pwd)/roles/translator/config-examples/tproxy-config-local-jdc-example.toml";
+     bitcoind-testnet.exec = "bitcoind -testnet4 -sv2 -sv2port=8442 -debug=sv2 -conf=$(pwd)/bitcoin.conf";
      run-minerd.exec = "minerd -a sha256d -o stratum+tcp://localhost:34255 -q -D -P";
   };
 

--- a/devenv.nix
+++ b/devenv.nix
@@ -57,4 +57,18 @@ in {
   pre-commit.hooks = {
     alejandra.enable = true;
   };
+
+  enterShell = ''
+    echo Just
+    echo ====
+    just --list
+    echo
+    echo Helper scripts
+    echo ==============
+    echo
+    ${pkgs.gnused}/bin/sed -e 's| |••|g' -e 's|=| |' <<EOF | ${pkgs.util-linuxMinimal}/bin/column -t | ${pkgs.gnused}/bin/sed -e 's|^| |' -e 's|••| |g'
+    ${lib.generators.toKeyValue {} (lib.mapAttrs (name: value: value.description) config.scripts)}
+    EOF
+    echo
+  '';
 }

--- a/devenv.nix
+++ b/devenv.nix
@@ -24,13 +24,26 @@ let
   });
 in {
   # https://devenv.sh/packages/
-  packages = [ bitcoind minerd pkgs.darwin.apple_sdk.frameworks.Security ];
+  packages = [ bitcoind minerd ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [ pkgs.darwin.apple_sdk.frameworks.Security ];
 
   # https://devenv.sh/languages/
   languages.rust.enable = true;
 
   # https://devenv.sh/processes/
   processes = {
+     run-local-pool.exec = "run-local-pool";
+     run-job-server.exec = "run-job-server";
+     run-job-client.exec = "run-job-client";
+     run-translator-proxy.exec = "run-translator-proxy";
+     bitcoind-testnet.exec = "bitcoind-testnet";
+     run-minerd.exec = "run-minerd";
+  };
+
+  # https://devenv.sh/basics/
+  # https://devenv.sh/services/
+  # services.postgres.enable = true;
+  # https://devenv.sh/scripts/
+  scripts = {
      run-local-pool.exec = "cargo -C roles/pool -Z unstable-options run -- -c $(pwd)/roles/pool/config-examples/pool-config-local-tp-example.toml";
      run-job-server.exec = "cargo -C roles/jd-server -Z unstable-options run -- -c $(pwd)/roles/jd-server/config-examples/jds-config-local-example.toml";
      run-job-client.exec = "cargo -C roles/jd-client -Z unstable-options run -- -c $(pwd)/roles/jd-client/config-examples/jdc-config-local-example.toml";
@@ -39,10 +52,6 @@ in {
      run-minerd.exec = "minerd -a sha256d -o stratum+tcp://localhost:34255 -q -D -P";
   };
 
-  # https://devenv.sh/basics/
-  # https://devenv.sh/services/
-  # services.postgres.enable = true;
-  # https://devenv.sh/scripts/
   # https://devenv.sh/tasks/
   # https://devenv.sh/tests/
   # https://devenv.sh/pre-commit-hooks/

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,0 +1,38 @@
+{ pkgs, lib, config, inputs, ... }:
+let
+  minerd = import ./cpuminer.nix {inherit pkgs;};
+  # override bitcoin's src attribute to get version 28
+  bitcoind = pkgs.bitcoind.overrideAttrs (final: rec {
+    version = "28.0";
+    src = pkgs.fetchurl {
+      urls = [
+        "https://bitcoincore.org/bin/bitcoin-core-${version}/bitcoin-${version}.tar.gz"
+      ];
+      sha256 = "sha256-cAri0eIEYC6wfyd5puZmmJO8lsDcopBZP4D/jhAv838=";
+  };});
+in {
+  # https://devenv.sh/packages/
+  packages = [ bitcoind minerd ];
+
+  # https://devenv.sh/languages/
+  languages.rust.enable = true;
+
+  # https://devenv.sh/processes/
+  processes = {
+     run-local-pool.exec = "cargo -C roles/pool -Z unstable-options run -- -c roles/pool/config-examples/pool-config-local-tp-example.toml";
+     run-job-server.exec = "cargo -C roles/jd-server -Z unstable-options run -- -c roles/jd-server/config-examples/jds-config-local-example.toml";
+     run-job-client.exec = "cargo -C roles/jd-client -Z unstable-options run -- -c roles/jd-client/config-examples/jds-config-local-example.toml";
+     run-translator-proxy.exec = "cargo -C roles/translator -Z unstable-options run -- -c roles/translator/config-examples/tproxy-config-local-jdc-example.toml";
+     bitcoind-testnet.exec = "bitcoind -daemon -testnet4 -sv2 -sv2port=8442 -debug=sv2";
+     run-minerd.exec = "minerd -a sha256d -o stratum+tcp://localhost:34255 -q -D -P";
+  };
+
+  # https://devenv.sh/basics/
+  # https://devenv.sh/services/
+  # services.postgres.enable = true;
+  # https://devenv.sh/scripts/
+  # https://devenv.sh/tasks/
+  # https://devenv.sh/tests/
+  # https://devenv.sh/pre-commit-hooks/
+  # See full reference at https://devenv.sh/reference/options/
+}

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -1,0 +1,8 @@
+inputs:
+  cdk:
+    url: github:cashubtc/cdk
+    inputs:
+      nixpkgs:
+        follows: nixpkgs
+  nixpkgs:
+    url: github:cachix/devenv-nixpkgs/rolling

--- a/justfile
+++ b/justfile
@@ -1,2 +1,7 @@
+# format nix files
 formatnix:
 	alejandra .
+
+# start developement processes
+up:
+	devenv up

--- a/justfile
+++ b/justfile
@@ -1,0 +1,2 @@
+formatnix:
+	alejandra .


### PR DESCRIPTION
declares processes for each stratum thing, bitcoin 28, and cpuminer via devenv, see https://devenv.sh and install, or run 'devenv up' to set up env. This is a nicer solution than #2  imo. 

@gotcha made the great point that your use case was good for [devenv](https://devenv.sh). You can declaratively define your env and the processes you want stood up. Once installed, run `devenv up` and you'll have a nice process management UI.

We packaged `minerd` and overrode `bitcoind` so you could get `testnet4` working. There may other issues depending on setup intricacies we haven't tested, but this should be a good start. 

Let me know if you have questions on it!